### PR TITLE
changed passenger cookbook and template

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,8 +4,9 @@ maintainer_email 'vik@vikbhatti.com'
 license          'All rights reserved'
 description      'Installs/Configures sinatra app'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.2.0'
 
 depends "apt"
 depends "git"
 depends "apache2"
+depends "passenger_apache2"

--- a/recipes/brightbox-passenger.rb
+++ b/recipes/brightbox-passenger.rb
@@ -1,7 +1,0 @@
-include_recipe 'sinatra_app::brightbox-ppa'
-
-package 'libapache2-mod-passenger' do
-  action :upgrade
-  only_if {node[:platform].eql?('ubuntu')}
-  notifies :restart, "service[apache2]"
-end

--- a/recipes/brightbox-ppa.rb
+++ b/recipes/brightbox-ppa.rb
@@ -1,8 +1,0 @@
-include_recipe "apt"
-
-apt_repository "brightbox" do
-  uri "http://ppa.launchpad.net/brightbox/passenger"
-  distribution node['lsb']['codename']
-  keyserver "keyserver.ubuntu.com"
-  key "C3173AA6"
-end

--- a/recipes/webserver.rb
+++ b/recipes/webserver.rb
@@ -9,7 +9,7 @@
 
 include_recipe 'apache2'
 include_recipe 'git'
-include_recipe 'sinatra_app::brightbox-passenger'
+include_recipe 'passenger_apache2::mod_rails'
 
 app_name = node[:sinatra_app][:server_name]
 

--- a/templates/default/sinatra_app.conf.erb
+++ b/templates/default/sinatra_app.conf.erb
@@ -8,9 +8,10 @@
     CustomLog <%= @node[:apache][:log_dir] %>/access-<%= @params[:server_name] %>.log combined
     
     <Directory <%= "#{@params[:docroot]}/public" %>>
-        Options FollowSymLinks -MultiViews
+        Options +FollowSymLinks -MultiViews
         AllowOverride All
         Order allow,deny
         Allow from all
+        Require all granted
     </Directory>
 </VirtualHost>


### PR DESCRIPTION
I had no luck with the brightbox hosted passenger install, so I switched to using the passenger_apache2 cookbook and include the mod_rails recipe so it installs and activates the module in apache2. I got this to work on the first pass on a freshly provisioned Ubuntu 14.04 node on DigitalOcean, for what that's worth.
